### PR TITLE
[Refactor] Use full GPT insights for symbol-specific, confidence-weighted stock prediction

### DIFF
--- a/evaluation/evaluator.py
+++ b/evaluation/evaluator.py
@@ -25,8 +25,21 @@ class Evaluator:
 
     def evaluate(self, symbol: str):
         report_path = self._latest_report()
-        date_str = report_path.stem.split('-')[-1]
+        parts = report_path.stem.split('-')
+        date_str = '-'.join(parts[-3:])
         report_date = datetime.strptime(date_str, '%Y-%m-%d')
+
+        # extract predicted movement score from report
+        predicted_value = 0.0
+        with open(report_path, 'r') as f:
+            for line in f:
+                if line.lower().startswith('predicted movement score'):
+                    try:
+                        predicted_value = float(line.split(':')[-1].strip())
+                    except ValueError:
+                        predicted_value = 0.0
+                    break
+
         # fetch actual close price for next day using AlphaVantage
         params = {
             'function': 'TIME_SERIES_DAILY_ADJUSTED',
@@ -39,15 +52,44 @@ class Evaluator:
         series = data.get('Time Series (Daily)', {})
         next_day = (report_date + timedelta(days=1)).strftime('%Y-%m-%d')
         actual = series.get(next_day, {})
-        closing = actual.get('4. close')
+        closing_next = actual.get('4. close')
+        prev = series.get(report_date.strftime('%Y-%m-%d'), {})
+        closing_prev = prev.get('4. close')
+
+        predicted_direction = 'up' if predicted_value > 0.05 else 'down' if predicted_value < -0.05 else 'neutral'
+        actual_direction = None
+        if closing_next and closing_prev:
+            try:
+                next_val = float(closing_next)
+                prev_val = float(closing_prev)
+                if next_val > prev_val:
+                    actual_direction = 'up'
+                elif next_val < prev_val:
+                    actual_direction = 'down'
+                else:
+                    actual_direction = 'neutral'
+            except ValueError:
+                pass
 
         eval_date = datetime.utcnow().strftime('%Y-%m-%d')
         filename = EVAL_DIR / f'evaluation-{eval_date}.md'
         lines = [f"# Evaluation - {eval_date}", f"Report evaluated: {report_path.name}"]
-        if closing:
-            lines.append(f"Actual closing price on {next_day}: {closing}")
+        if closing_next:
+            lines.append(f"Actual closing price on {next_day}: {closing_next}")
         else:
             lines.append(f"No data for {next_day}")
+
+        if closing_prev:
+            lines.append(f"Previous close on {report_date.strftime('%Y-%m-%d')}: {closing_prev}")
+        if actual_direction:
+            lines.append(f"Actual direction: {actual_direction}")
+        else:
+            lines.append("Actual direction: unknown")
+
+        lines.append(f"Predicted direction: {predicted_direction}")
+        if actual_direction:
+            correct = 'yes' if actual_direction == predicted_direction else 'no'
+            lines.append(f"Prediction correct?: {correct}")
         filename.write_text('\n'.join(lines))
         self.repo.git.add(str(filename))
         self.repo.index.commit(f"Add evaluation report for {eval_date}")

--- a/evaluations/evaluation-2025-07-19.md
+++ b/evaluations/evaluation-2025-07-19.md
@@ -1,0 +1,5 @@
+# Evaluation - 2025-07-19
+Report evaluated: prediction-2025-07-19.md
+No data for 2025-07-20
+Actual direction: unknown
+Predicted direction: neutral

--- a/main.py
+++ b/main.py
@@ -14,9 +14,9 @@ def gather_flow(query: str = 'stock market', symbol: str = 'AAPL'):
 
     news = news_fetcher.fetch(query)
     texts = [item['title'] for item in news]
-    sentiments = analyzer.analyze(texts)
-    prediction = predictor.predict(sentiments)
-    report_path = reporter.generate_report(news, sentiments, prediction)
+    insights = analyzer.analyze(texts, symbol)
+    prediction = predictor.predict(insights, symbol)
+    report_path = reporter.generate_report(news, insights, prediction, symbol)
     print(f"Report generated at {report_path}")
 
 

--- a/predictor/predictor.py
+++ b/predictor/predictor.py
@@ -1,8 +1,32 @@
-from typing import List
+from typing import List, Dict
 
 class StockPredictor:
-    def predict(self, sentiments: List[float]) -> float:
-        """Simple heuristic: average sentiment as proxy for next day movement."""
-        if not sentiments:
+    def predict(self, insights: List[Dict], symbol: str) -> float:
+        """Return confidence-weighted sentiment for the specified symbol."""
+        if not insights:
             return 0.0
-        return sum(sentiments) / len(sentiments)
+
+        # filter insights referencing the target symbol
+        symbol_upper = symbol.upper()
+        relevant = []
+        for item in insights:
+            entities = item.get('affected_entities', []) or []
+            entities_upper = [str(e).upper() for e in entities]
+            if symbol_upper in entities_upper:
+                relevant.append(item)
+
+        if not relevant:
+            return 0.0
+
+        numerator = 0.0
+        denominator = 0.0
+        for item in relevant:
+            sentiment = float(item.get('sentiment', 0.0))
+            confidence = float(item.get('confidence_score', 0.0))
+            numerator += sentiment * confidence
+            denominator += confidence
+
+        if denominator == 0:
+            return 0.0
+
+        return numerator / denominator

--- a/reporting/markdown_reporter.py
+++ b/reporting/markdown_reporter.py
@@ -12,18 +12,43 @@ class MarkdownReporter:
         REPORT_DIR.mkdir(exist_ok=True)
         self.repo = Repo(Path(__file__).resolve().parents[1])
 
-    def generate_report(self, news_items, sentiments, prediction) -> Path:
+    def generate_report(self, news_items, insights, prediction, symbol: str) -> Path:
         date_str = datetime.utcnow().strftime('%Y-%m-%d')
         filename = REPORT_DIR / f'prediction-{date_str}.md'
         nodes = {'A': 'Fetch News', 'B': 'Analyze Sentiment', 'C': 'Predict Stock'}
         edges = [('A', 'B'), ('B', 'C')]
         diagram = flowchart(nodes, edges)
-        lines = [f"# Stock Prediction Report - {date_str}", '', '## News Headlines']
-        for item, sentiment in zip(news_items, sentiments):
-            lines.append(f"- {item.get('title')} (sentiment: {sentiment:+.2f})")
+        lines = [f"# Stock Prediction Report - {date_str}", f"**Symbol:** {symbol}", '', '## News Headlines']
+        for item in news_items:
+            lines.append(f"- {item.get('title')}")
+
+        # Filter insights relevant to symbol
+        symbol_upper = symbol.upper()
+        relevant = []
+        for ins in insights:
+            entities = [str(e).upper() for e in ins.get('affected_entities', [])]
+            if symbol_upper in entities:
+                relevant.append(ins)
+
+        lines.append('')
+        lines.append('## Relevant Insights')
+        if not relevant:
+            lines.append('No direct references to this symbol found.')
+        else:
+            for ins in relevant:
+                sentiment = float(ins.get('sentiment', 0.0))
+                rationale = ins.get('rationale', '')
+                conf = float(ins.get('confidence_score', 0.0))
+                lines.append(f"- Sentiment: {sentiment:+.2f} | Confidence: {conf:.1f}%")
+                if rationale:
+                    lines.append(f"  - Rationale: {rationale}")
+
+        direction = 'up' if prediction > 0.05 else 'down' if prediction < -0.05 else 'neutral'
+
         lines.append('')
         lines.append('## Prediction')
         lines.append(f"Predicted movement score: {prediction:+.2f}")
+        lines.append(f"Predicted direction: **{direction}**")
         lines.append('')
         lines.append('## Process Diagram')
         lines.append(diagram)

--- a/reports/prediction-2025-07-19.md
+++ b/reports/prediction-2025-07-19.md
@@ -1,0 +1,26 @@
+# Stock Prediction Report - 2025-07-19
+**Symbol:** AAPL
+
+## News Headlines
+- The End of the Stock Market As We Know It
+- DJI Osmo Action 4 in 4K/120fps Costs Peanuts, Amazon Clears Stock at Record Low for Early Prime Day
+- Wall Street’s AI Bubble Is Worse Than the 1999 Dot-com Bubble, Warns a Top Economist
+- This Card-Slim MagSafe Portable Power Bank Is Going for Peanuts, Limited Stock for This Early Prime Day Deal
+- If You Have PS5, Crucial T500 Gaming SSD Drops Nearly 50% for Early Prime Day, Limited Stock Available
+
+## Relevant Insights
+No direct references to this symbol found.
+
+## Prediction
+Predicted movement score: +0.00
+Predicted direction: **neutral**
+
+## Process Diagram
+```mermaid
+flowchart TD
+    A[Fetch News]
+    B[Analyze Sentiment]
+    C[Predict Stock]
+    A--> B
+    B--> C
+```


### PR DESCRIPTION
## Summary
- parse and return structured sentiment info from GPT in `SentimentAnalyzer`
- add confidence-weighted, symbol-specific logic in `StockPredictor`
- update pipeline in `main.py` to use new insights and pass the target symbol
- generate richer markdown reports with insight details and predicted direction
- evaluate predictions versus actual stock movement

## Testing
- `python main.py gather`
- `python main.py evaluate`


------
https://chatgpt.com/codex/tasks/task_e_687b1816caa48331903601b5ad039c3c