### PR TITLE
Implement structured sentiment insights and richer evaluations

### DIFF
--- a/evaluations/evaluation-2025-07-19.md
+++ b/evaluations/evaluation-2025-07-19.md
@@ -2,4 +2,5 @@
 Report evaluated: prediction-2025-07-19.md
 No data for 2025-07-20
 Actual direction: unknown
+Prediction score: +0.0000
 Predicted direction: neutral

--- a/reporting/markdown_reporter.py
+++ b/reporting/markdown_reporter.py
@@ -24,31 +24,42 @@ class MarkdownReporter:
 
         # Filter insights relevant to symbol
         symbol_upper = symbol.upper()
-        relevant = []
+        relevant: list[dict] = []
         for ins in insights:
             entities = [str(e).upper() for e in ins.get('affected_entities', [])]
             if symbol_upper in entities:
                 relevant.append(ins)
 
         lines.append('')
-        lines.append('## Relevant Insights')
+        lines.append(f'## Relevant Insights for {symbol_upper}')
         if not relevant:
             lines.append('No direct references to this symbol found.')
         else:
             for ins in relevant:
                 sentiment = float(ins.get('sentiment', 0.0))
-                rationale = ins.get('rationale', '')
                 conf = float(ins.get('confidence_score', 0.0))
-                lines.append(f"- Sentiment: {sentiment:+.2f} | Confidence: {conf:.1f}%")
+                duration = ins.get('impact_duration', '')
+                rationale = ins.get('rationale', '')
+                precedent = ins.get('precedent')
+                lines.append(f"- Sentiment: {sentiment:+.2f} | Confidence: {conf:.1f}% | Duration: {duration}")
                 if rationale:
                     lines.append(f"  - Rationale: {rationale}")
+                if precedent:
+                    lines.append(f"  - Precedent: {precedent}")
 
-        direction = 'up' if prediction > 0.05 else 'down' if prediction < -0.05 else 'neutral'
+        lines.append('')
+        lines.append(f'Matching insights: {len(relevant)}')
+        avg_conf = 0.0
+        if relevant:
+            avg_conf = sum(float(i.get('confidence_score', 0.0)) for i in relevant) / len(relevant)
+
+        direction_sign = '+' if prediction > 0.05 else '-' if prediction < -0.05 else '0'
 
         lines.append('')
         lines.append('## Prediction')
         lines.append(f"Predicted movement score: {prediction:+.2f}")
-        lines.append(f"Predicted direction: **{direction}**")
+        lines.append(f"Final predicted direction: {direction_sign}")
+        lines.append(f"Average confidence: {avg_conf:.1f}%")
         lines.append('')
         lines.append('## Process Diagram')
         lines.append(diagram)

--- a/reports/prediction-2025-07-19.md
+++ b/reports/prediction-2025-07-19.md
@@ -5,15 +5,18 @@
 - The End of the Stock Market As We Know It
 - DJI Osmo Action 4 in 4K/120fps Costs Peanuts, Amazon Clears Stock at Record Low for Early Prime Day
 - Wall Street’s AI Bubble Is Worse Than the 1999 Dot-com Bubble, Warns a Top Economist
-- This Card-Slim MagSafe Portable Power Bank Is Going for Peanuts, Limited Stock for This Early Prime Day Deal
+- AirPods Pro 2 Are Back at Their Lowest Price as Apple Clears Out Limited Stock on Amazon
 - If You Have PS5, Crucial T500 Gaming SSD Drops Nearly 50% for Early Prime Day, Limited Stock Available
 
-## Relevant Insights
+## Relevant Insights for AAPL
 No direct references to this symbol found.
+
+Matching insights: 0
 
 ## Prediction
 Predicted movement score: +0.00
-Predicted direction: **neutral**
+Final predicted direction: 0
+Average confidence: 0.0%
 
 ## Process Diagram
 ```mermaid


### PR DESCRIPTION
## Summary
- improve JSON extraction in sentiment analyzer
- refine Markdown reports with detailed insights per stock symbol
- compute evaluation metrics including delta error

## Testing
- `python main.py gather`
- `python main.py evaluate`


------
https://chatgpt.com/codex/tasks/task_e_687b1b63607083319238910acd08521f