### PR TITLE
Refactor for SOLID principles and add tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+    */*.json
+    */*.txt
+    */*.md

--- a/learn_new_stocks.py
+++ b/learn_new_stocks.py
@@ -1,25 +1,19 @@
-import json
 import logging
 from pathlib import Path
 from typing import List, Dict
 
 from gather.news_fetcher import NewsFetcher
+from watchlist import WatchlistManager
 
 WATCHLIST_PATH = Path("watchlist.json")
 
 
 def load_watchlist(path: Path = WATCHLIST_PATH) -> List[Dict]:
-    if path.exists():
-        try:
-            return json.loads(path.read_text())
-        except Exception as e:
-            logging.exception("Failed to parse watchlist: %s", e)
-            return []
-    return []
+    return WatchlistManager(path).load()
 
 
 def save_watchlist(data: List[Dict], path: Path = WATCHLIST_PATH) -> None:
-    path.write_text(json.dumps(data, indent=2))
+    WatchlistManager(path).save(data)
 
 
 def learn_new_stocks(query: str = "stock market") -> None:

--- a/repo_utils.py
+++ b/repo_utils.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import Protocol
+from git import Repo
+
+
+class Committer(Protocol):
+    """Abstraction for committing files."""
+
+    def add_and_commit(self, path: Path, message: str) -> None:
+        ...
+
+
+class GitCommitter:
+    """Commit files using GitPython."""
+
+    def __init__(self, repo_path: Path):
+        self.repo = Repo(repo_path)
+
+    def add_and_commit(self, path: Path, message: str) -> None:
+        self.repo.git.add(str(path))
+        self.repo.index.commit(message)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,52 @@
+import json
+from datetime import datetime
+from pathlib import Path
+import types
+
+import evaluation.evaluator as evaluator_mod
+from evaluation.evaluator import Evaluator
+
+
+class DummyCommitter:
+    def add_and_commit(self, path: Path, message: str) -> None:
+        pass
+
+
+def test_fetch_actual_direction_up(monkeypatch):
+    evalr = Evaluator(stock_api_key="k", committer=DummyCommitter())
+    data = {
+        "Time Series (Daily)": {
+            "2025-07-31": {"4. close": "101"},
+            "2025-07-30": {"4. close": "100"},
+        }
+    }
+
+    class Resp:
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return data
+
+    def fake_get(url, params, timeout):
+        return Resp()
+
+    monkeypatch.setattr(evaluator_mod, "requests", types.SimpleNamespace(get=fake_get))
+    direction = evalr._fetch_actual_direction("ABC", datetime(2025, 7, 30))
+    assert direction == "up"
+
+
+def test_evaluate_creates_file(monkeypatch, tmp_path):
+    report = {"date": "2025-07-30", "results": [{"symbol": "ABC", "prediction": {"direction": "up", "confidence": {"value": 70}}}]}
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps(report))
+    hist_path = tmp_path / "history.jsonl"
+    monkeypatch.setattr(evaluator_mod, "HISTORY_LOG", hist_path)
+    monkeypatch.setattr(Evaluator, "_previous_report", lambda self: report_path)
+    monkeypatch.setattr(Evaluator, "_fetch_actual_direction", lambda self, s, d: "down")
+    monkeypatch.setattr(evaluator_mod, "EVAL_DIR", tmp_path)
+    evalr = Evaluator(stock_api_key="k", committer=DummyCommitter())
+    out = evalr.evaluate(["ABC"], commit=False)
+    assert out.exists()
+    data = out.read_text()
+    assert "ABC" in data
+    assert hist_path.exists()

--- a/tests/test_prediction_adjuster.py
+++ b/tests/test_prediction_adjuster.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from prediction_adjuster import analyze
+
+
+def test_analyze_metrics(tmp_path: Path):
+    data = [
+        {"date": "2025-07-29", "symbol": "ABC", "predicted_direction": "up", "confidence": 70, "accuracy": True},
+        {"date": "2025-07-30", "symbol": "ABC", "predicted_direction": "up", "confidence": 80, "accuracy": False},
+        {"date": "2025-07-30", "symbol": "XYZ", "predicted_direction": "down", "confidence": 50, "accuracy": True},
+    ]
+    log_path = tmp_path / "log.jsonl"
+    log_path.write_text("\n".join([__import__('json').dumps(d) for d in data]))
+    metrics = analyze(log_path=log_path, days=7)
+    assert metrics["ABC"]["accuracy_rate"] == 0.5
+    assert metrics["XYZ"]["accuracy_rate"] == 1.0

--- a/tests/test_relevance_matcher.py
+++ b/tests/test_relevance_matcher.py
@@ -1,0 +1,20 @@
+import pytest
+from relevance_matcher import RelevanceMatcher
+
+
+def test_score_exact_match():
+    matcher = RelevanceMatcher({'ABC': ['Alpha']})
+    score, kw = matcher.score('Alpha launches new product', 'ABC')
+    assert score == 1.0
+    assert kw == 'Alpha'
+
+
+def test_match_headlines_threshold():
+    matcher = RelevanceMatcher({'ABC': ['Alpha']})
+    items = [
+        {'title': 'Alpha announces earnings', 'publishedAt': '2025-07-30'},
+        {'title': 'Other company news', 'publishedAt': '2025-07-30'},
+    ]
+    matches = matcher.match_headlines(items, 'ABC', threshold=0.5)
+    assert len(matches) == 1
+    assert matches[0]['title'] == 'Alpha announces earnings'

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -1,0 +1,14 @@
+from report_writer import ReportWriter
+
+
+def test_recommendation_and_turnover():
+    writer = ReportWriter()
+    rec, turn = writer.recommendation_and_turnover(0.3, 70, 'High')
+    assert rec == 'BUY'
+    assert turn == '2-3 days'
+    rec, turn = writer.recommendation_and_turnover(-0.3, 50, 'Low')
+    assert rec == 'AVOID'
+    assert turn == '7-10 days'
+    rec, turn = writer.recommendation_and_turnover(0.0, 40, 'Medium')
+    assert rec == 'HOLD'
+    assert turn == '4-7 days'

--- a/tests/test_sentiment_analyzer.py
+++ b/tests/test_sentiment_analyzer.py
@@ -1,0 +1,21 @@
+from datetime import datetime, timedelta
+from gather.sentiment_analyzer import SentimentAnalyzer
+
+
+def test_weighted_score_prefers_recent():
+    analyzer = SentimentAnalyzer()
+    now = datetime.utcnow()
+    items = [
+        {'sentiment': 0.8, 'relevance_score': 1.0, 'publishedAt': now.isoformat()},
+        {'sentiment': -0.8, 'relevance_score': 1.0, 'publishedAt': (now - timedelta(days=10)).isoformat()},
+    ]
+    score = analyzer.weighted_score(items)
+    assert score > 0
+
+
+def test_confidence_scoring():
+    analyzer = SentimentAnalyzer()
+    items = [{'sentiment': 0.5, 'relevance_score': 0.5} for _ in range(3)]
+    value, label = analyzer.confidence(items)
+    assert 0 <= value <= 100
+    assert label in {'High', 'Medium', 'Low'}

--- a/tests/test_stock_predictor.py
+++ b/tests/test_stock_predictor.py
@@ -1,0 +1,18 @@
+from predictor.predictor import StockPredictor
+
+
+def test_predict_weighted_average():
+    predictor = StockPredictor()
+    insights = [
+        {'affected_entities': ['XYZ'], 'sentiment': 0.5, 'confidence_score': 60},
+        {'affected_entities': ['XYZ'], 'sentiment': -0.5, 'confidence_score': 40},
+    ]
+    result = predictor.predict(insights, 'XYZ')
+    # weighted average: (0.5*60 + (-0.5*40)) / (60+40) = 0.1
+    assert round(result, 2) == 0.10
+
+
+def test_predict_no_relevant_insights():
+    predictor = StockPredictor()
+    insights = [{'affected_entities': ['ABC'], 'sentiment': 1.0, 'confidence_score': 100}]
+    assert predictor.predict(insights, 'XYZ') == 0.0

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+from watchlist import WatchlistManager
+
+
+def test_watchlist_load_and_save(tmp_path: Path):
+    manager = WatchlistManager(tmp_path / 'wl.json')
+    assert manager.load() == []
+    data = [{'symbol': 'ABC'}]
+    manager.save(data)
+    assert manager.load() == data

--- a/watchlist.py
+++ b/watchlist.py
@@ -1,0 +1,25 @@
+import json
+import logging
+from pathlib import Path
+from typing import List, Dict
+
+
+class WatchlistManager:
+    """Load and save watchlist entries from a JSON file."""
+
+    def __init__(self, path: str | Path = "watchlist.json") -> None:
+        self.path = Path(path)
+
+    def load(self) -> List[Dict]:
+        if not self.path.exists():
+            return []
+        try:
+            data = json.loads(self.path.read_text())
+            if isinstance(data, list):
+                return data
+        except Exception as e:  # pragma: no cover - logging
+            logging.exception("Failed to parse watchlist: %s", e)
+        return []
+
+    def save(self, entries: List[Dict]) -> None:
+        self.path.write_text(json.dumps(entries, indent=2))


### PR DESCRIPTION
## Summary
- introduce `WatchlistManager` abstraction
- decouple git commits via `repo_utils.GitCommitter`
- refactor report writer and evaluator to use the committer
- update `main` and `learn_new_stocks` to use new watchlist loader
- add unit tests for key modules
- configure coverage exclusions

## Testing
- `python -m pytest -q --cov=. --cov-report=term`

------
https://chatgpt.com/codex/tasks/task_e_688993b3720483318b75c2707b7904fa